### PR TITLE
Update bolt version output and migrate --targets to the end of commands

### DIFF
--- a/Linux/lab-02.1-Install-Puppet-Bolt/README.md
+++ b/Linux/lab-02.1-Install-Puppet-Bolt/README.md
@@ -61,7 +61,7 @@ Note that your version might be slightly different.
 
 ```plaintext
 $ bolt --version
-1.39.0
+2.6.0
 ```
 
 #### Run Bolt

--- a/Linux/lab-02.2-Running-Bolt-Commands/README.md
+++ b/Linux/lab-02.2-Running-Bolt-Commands/README.md
@@ -46,7 +46,7 @@ Now you will start the time service on a remote machine, which is a bit more int
 
 On your Linux machine, run the following in a terminal window:
 
-```bolt command run 'net start w32time' --targets winrm://<your-windows-machine>.classroom.puppet.com --user Administrator --no-ssl --password-prompt```
+```bolt command run 'net start w32time' --user Administrator --no-ssl --password-prompt --targets winrm://<your-windows-machine>.classroom.puppet.com```
 
 **_You will be prompted for a password._**
 
@@ -62,7 +62,7 @@ STDOUT:
 
 On your Linux machine, run the following in a terminal window:
 
-```bolt command run 'Get-Service w32time' --targets winrm://<your-windows-machine>.classroom.puppet.com --user Administrator --no-ssl --password-prompt```
+```bolt command run 'Get-Service w32time' --user Administrator --no-ssl --password-prompt --targets winrm://<your-windows-machine>.classroom.puppet.com```
 
 **_You will be prompted for a password._**
 
@@ -94,7 +94,7 @@ In this exercise you will run a script against your remote host. Regardless of p
 
 On your Linux machine, run the following in a terminal window:
 
-```bolt script run /tools/windows.ps1 --targets winrm://<your-windows-machine>.classroom.puppet.com --user Administrator --no-ssl --password-prompt```
+```bolt script run /tools/windows.ps1 --user Administrator --no-ssl --password-prompt --targets winrm://<your-windows-machine>.classroom.puppet.com```
 
 The output will look similar to the following:
 

--- a/Windows/lab-02.1-Install-Puppet-Bolt/README.md
+++ b/Windows/lab-02.1-Install-Puppet-Bolt/README.md
@@ -39,7 +39,7 @@ Note that your version might be slightly different.
 
 ```plaintext
    PS C:\Users\Administrator> bolt --version
-   1.39.0
+   2.6.0
 ```
 
 Open a new PowerShell window and run:

--- a/Windows/lab-02.2-Running-Bolt-Commands/README.md
+++ b/Windows/lab-02.2-Running-Bolt-Commands/README.md
@@ -50,7 +50,7 @@ Now you will start the time service on a remote machine, which is a bit more int
 
 On your Windows machine, run the following in a PowerShell window:
 
-```bolt command run 'sudo systemctl start ntpd' --targets ssh://<your-linux-machine>.classroom.puppet.com --private-key C:\keys\private_key.pem --user centos --no-host-key-check```
+```bolt command run 'sudo systemctl start ntpd' --private-key C:\keys\private_key.pem --user centos --no-host-key-check --targets ssh://<your-linux-machine>.classroom.puppet.com ```
 
 **_This runs a command on just one remote host. Instead, you could have supplied a list of hosts to run simultaneously - or even an entire inventory file of hosts._**
 
@@ -67,7 +67,7 @@ The output will look similar to the following:
 
 Run the following in a PowerShell window:
 
-```bolt command run 'sudo systemctl status ntpd' --targets ssh://<your-linux-machine>.classroom.puppet.com --private-key C:\keys\private_key.pem --user centos --no-host-key-check```
+```bolt command run 'sudo systemctl status ntpd' --private-key C:\keys\private_key.pem --user centos --no-host-key-check --targets ssh://<your-linux-machine>.classroom.puppet.com```
 
 The output will look similar to the following:
 
@@ -101,7 +101,7 @@ In this exercise you will run a script against your remote host. Regardless of p
 
 On your Windows machine, run the following in a PowerShell window:
 
-```bolt script run C:\tools\linux.sh --targets ssh://<your-linux-machine>.classroom.puppet.com --private-key C:\keys\private_key.pem --user centos --no-host-key-check --run-as root```
+```bolt script run C:\tools\linux.sh --private-key C:\keys\private_key.pem --user centos --no-host-key-check --run-as root --targets ssh://<your-linux-machine>.classroom.puppet.com```
 
 **_Notice the use of `--run-as`. This allows us to handle permission escalations. In this case you are authenticating as `centos` and then changing the user to `root` (via sudo) when the script executes. Your user has no password access to run `sudo`, but if you have a separate `sudo` password you need to supply you can do that as well. See the output of `bolt -h` for details._**
 


### PR DESCRIPTION
This pull request is to upgrade the version of Bolt show in the example output to a newer version of bolt and to move the targets argument to the end of the commands to avoid students needing to manipulate the cursor as much.